### PR TITLE
fix: Fix interception logic for auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2023-07-10
+
+### Fixes
+
+- Fixed an issue where the Authorization header was getting removed unnecessarily
+
 ## [0.3.2] - 2023-06-06
 
 - Refactors session logic to delete access token and refresh token if the front token is removed. This helps with proxies that strip headers with empty values which would result in the access token and refresh token to persist after signout

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-def publishVersionID = "0.3.2"
+def publishVersionID = "0.3.3"
 
 android {
     compileSdkVersion 32

--- a/app/src/main/java/com/supertokens/session/SuperTokensCustomHttpURLConnection.java
+++ b/app/src/main/java/com/supertokens/session/SuperTokensCustomHttpURLConnection.java
@@ -250,7 +250,8 @@ public class SuperTokensCustomHttpURLConnection extends HttpURLConnection {
 
     private boolean shouldAllowSettingAuthHeader(String value) {
         String accessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, applicationContext);
-        if (accessToken != null && value.equals("Bearer " + accessToken)) {
+        String refreshToken = Utils.getTokenForHeaderAuth(Utils.TokenType.REFRESH, applicationContext);
+        if (accessToken != null && refreshToken != null && value.equals("Bearer " + accessToken)) {
             // We ignore the attempt to set the header because it matches the existing access token
             // which will get added by the SDK
             return false;

--- a/app/src/main/java/com/supertokens/session/SuperTokensInterceptor.java
+++ b/app/src/main/java/com/supertokens/session/SuperTokensInterceptor.java
@@ -43,8 +43,9 @@ public class SuperTokensInterceptor implements Interceptor {
 
         if (originalHeader != null) {
             String accessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, context);
+            String refreshToken = Utils.getTokenForHeaderAuth(Utils.TokenType.REFRESH, context);
 
-            if (accessToken != null && originalHeader.equals("Bearer " + accessToken)) {
+            if (accessToken != null && refreshToken != null && originalHeader.equals("Bearer " + accessToken)) {
                 builder.removeHeader("Authorization");
                 builder.removeHeader("authorization");
             }

--- a/testHelpers/server/index.js
+++ b/testHelpers/server/index.js
@@ -525,6 +525,15 @@ app.post("/logout-alt", async (req, res) => {
         .json({});
 });
 
+app.get("/base-custom-auth", async (req, res) => {
+    let header = req.headers["authorization"];
+    if (header === "Bearer myOwnHeHe") {
+        return res.status(200).json({message: "OK"});
+    } else {
+        return res.status(500).json({message: "Bad auth header"});
+    }
+})
+
 app.use("*", async (req, res, next) => {
     res.status(404).send();
 });

--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensRetrofitHeaderTests.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensRetrofitHeaderTests.java
@@ -723,6 +723,28 @@ public class SuperTokensRetrofitHeaderTests {
         assert refreshTokenAfter == null;
     }
 
+    @Test
+    public void retrofitHeaders_testThatAuthHeaderIsNotIgnoredEvenIfItMatchesTheStoredAccessToken() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .build();
+
+        JsonObject body = new JsonObject();
+        body.addProperty("userId", Constants.userId);
+        Response <Void> loginResponse = retrofitTestAPIService.login(body).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+
+        Thread.sleep(5000);
+        Utils.setToken(Utils.TokenType.ACCESS, "myOwnHeHe", context);
+
+        Response <Void> response2 = retrofitTestAPIService.baseCustomAuth("Bearer myOwnHeHe").execute();
+        if (response2.code() != 200) {
+            throw new Exception("Error making api request");
+        }
+    }
+
     class customInterceptors implements Interceptor {
         @NotNull
         @Override

--- a/testHelpers/testapp/app/src/test/java/com/example/example/android/RetrofitTestAPIService.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/android/RetrofitTestAPIService.java
@@ -31,6 +31,13 @@ public interface RetrofitTestAPIService {
     })
     Call<Void> login(@Body JsonObject body);
 
+    @GET("/base-custom-auth")
+    @Headers({
+            "Content-Type: application/json",
+            "Accept: application/json"
+    })
+    Call<Void> baseCustomAuth(@Header("authorization") String token);
+
     @POST("/login-2.18")
     @Headers({
             "Content-Type: application/json",


### PR DESCRIPTION
## Summary of change
Changes interception logic when adding the authorisation bearer token in the headers

## Related issues
- 

## Test Plan
Added new tests

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `app/src/main/java/com/supertokens/session/Version.java`
- [x] Changes to the version if needed
   - In `app/build.gradle`
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] ...