### PR TITLE
Session scope fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-04-08
+
+### Breaking changes
+
+The `shouldDoInterceptionBasedOnUrl` function now returns true: 
+- If `sessionTokenBackendDomain` is a valid subdomain of the URL's domain. This aligns with the behavior of browsers when sending cookies to subdomains.
+- Even if the ports of the URL you are querying are different compared to the `apiDomain`'s port ot the `sessionTokenBackendDomain` port (as long as the hostname is the same, or a subdomain of the `sessionTokenBackendDomain`): https://github.com/supertokens/supertokens-website/issues/217
+
+
 ## [0.3.6] - 2024-03-14
 
 - New FDI version support: 1.19

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-def publishVersionID = "0.3.6"
+def publishVersionID = "0.4.0"
 
 android {
     compileSdkVersion 32

--- a/examples/with-thirdparty/README.md
+++ b/examples/with-thirdparty/README.md
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
 Add the folliwing to your app level `build.gradle`
 
 ```gradle
-implementation("com.github.supertokens:supertokens-android:0.3.6")
+implementation("com.github.supertokens:supertokens-android:0.4.0")
 implementation ("com.google.android.gms:play-services-auth:20.7.0")
 implementation("com.squareup.retrofit2:retrofit:2.9.0")
 implementation("net.openid:appauth:0.11.1")

--- a/examples/with-thirdparty/app/build.gradle.kts
+++ b/examples/with-thirdparty/app/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.github.supertokens:supertokens-android:0.3.6")
+    implementation("com.github.supertokens:supertokens-android:0.4.0")
     implementation ("com.google.android.gms:play-services-auth:20.7.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("net.openid:appauth:0.11.1")

--- a/testHelpers/testapp/app/src/test/java/com/example/example/ConfigTests.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/ConfigTests.java
@@ -33,42 +33,43 @@ public class ConfigTests {
         return new NormalisedURLPath(input).getAsStringDangerous();
     }
 
-    private  String normaliseURLDomainOrThrowError(String input) throws MalformedURLException {
+    private String normaliseURLDomainOrThrowError(String input) throws MalformedURLException {
         return new NormalisedURLDomain(input).getAsStringDangerous();
     }
 
     @Test
     public void testSessionScopeNormalisation() throws Exception {
-        assert(normaliseSessionScopeOrThrowErrorForTests("api.example.com").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("http://api.example.com").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("https://api.example.com").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("http://api.example.com?hello=1").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("http://api.example.com/hello").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("http://api.example.com/").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("http://api.example.com:8080").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("http://api.example.com#random2").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("api.example.com/").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("api.example.com#random").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("example.com").equals("example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("api.example.com/?hello=1&bye=2").equals("api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("localhost").equals("localhost"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("localhost:8080").equals("localhost"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("localhost.org").equals("localhost.org"));
-        assert(normaliseSessionScopeOrThrowErrorForTests("127.0.0.1").equals("127.0.0.1"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("api.example.com").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("http://api.example.com").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("https://api.example.com").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("http://api.example.com?hello=1").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("http://api.example.com/hello").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("http://api.example.com/").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("http://api.example.com:8080").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("http://api.example.com#random2").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("api.example.com/").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("api.example.com#random").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("example.com").equals("example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("api.example.com/?hello=1&bye=2").equals("api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("localhost").equals("localhost"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("localhost:8080").equals("localhost"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("localhost.org").equals("localhost.org"));
+        assert (normaliseSessionScopeOrThrowErrorForTests("127.0.0.1").equals("127.0.0.1"));
 
-        assert(normaliseSessionScopeOrThrowErrorForTests(".api.example.com").equals(".api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".api.example.com/").equals(".api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".api.example.com#random").equals(".api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".example.com").equals(".example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".api.example.com/?hello=1&bye=2").equals(".api.example.com"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".localhost").equals("localhost"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".localhost:8080").equals("localhost"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".localhost.org").equals(".localhost.org"));
-        assert(normaliseSessionScopeOrThrowErrorForTests(".127.0.0.1").equals("127.0.0.1"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".api.example.com").equals(".api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".api.example.com/").equals(".api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".api.example.com#random").equals(".api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".example.com").equals(".example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".api.example.com/?hello=1&bye=2")
+                .equals(".api.example.com"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".localhost").equals("localhost"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".localhost:8080").equals("localhost"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".localhost.org").equals(".localhost.org"));
+        assert (normaliseSessionScopeOrThrowErrorForTests(".127.0.0.1").equals("127.0.0.1"));
 
         try {
             normaliseSessionScopeOrThrowErrorForTests("http://");
-            assert(false);
+            assert (false);
         } catch (Exception e) {
             assert e.getMessage().equals("Please provide a valid sessionScope");
         }
@@ -76,186 +77,208 @@ public class ConfigTests {
 
     @Test
     public void testingURLPathNormalisation() throws Exception {
-        assert(normaliseURLPathOrThrowError("exists?email=john.doe%40gmail.com").equals("/exists"));
-        assert(
-                normaliseURLPathOrThrowError("/auth/email/exists?email=john.doe%40gmail.com").equals("/auth/email/exists")
-        );
-        assert(normaliseURLPathOrThrowError("exists").equals("/exists"));
-        assert(normaliseURLPathOrThrowError("/exists").equals("/exists"));
-        assert(normaliseURLPathOrThrowError("/exists?email=john.doe%40gmail.com").equals("/exists"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com").equals(""));
-        assert(normaliseURLPathOrThrowError("https://api.example.com").equals(""));
-        assert(normaliseURLPathOrThrowError("http://api.example.com?hello=1").equals(""));
-        assert(normaliseURLPathOrThrowError("http://api.example.com/hello").equals("/hello"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com/").equals(""));
-        assert(normaliseURLPathOrThrowError("http://api.example.com:8080").equals(""));
-        assert(normaliseURLPathOrThrowError("http://api.example.com#random2").equals(""));
-        assert(normaliseURLPathOrThrowError("api.example.com/").equals(""));
-        assert(normaliseURLPathOrThrowError("api.example.com#random").equals(""));
-        assert(normaliseURLPathOrThrowError(".example.com").equals(""));
-        assert(normaliseURLPathOrThrowError("api.example.com/?hello=1&bye=2").equals(""));
+        assert (normaliseURLPathOrThrowError("exists?email=john.doe%40gmail.com").equals("/exists"));
+        assert (normaliseURLPathOrThrowError("/auth/email/exists?email=john.doe%40gmail.com")
+                .equals("/auth/email/exists"));
+        assert (normaliseURLPathOrThrowError("exists").equals("/exists"));
+        assert (normaliseURLPathOrThrowError("/exists").equals("/exists"));
+        assert (normaliseURLPathOrThrowError("/exists?email=john.doe%40gmail.com").equals("/exists"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com").equals(""));
+        assert (normaliseURLPathOrThrowError("https://api.example.com").equals(""));
+        assert (normaliseURLPathOrThrowError("http://api.example.com?hello=1").equals(""));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/hello").equals("/hello"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/").equals(""));
+        assert (normaliseURLPathOrThrowError("http://api.example.com:8080").equals(""));
+        assert (normaliseURLPathOrThrowError("http://api.example.com#random2").equals(""));
+        assert (normaliseURLPathOrThrowError("api.example.com/").equals(""));
+        assert (normaliseURLPathOrThrowError("api.example.com#random").equals(""));
+        assert (normaliseURLPathOrThrowError(".example.com").equals(""));
+        assert (normaliseURLPathOrThrowError("api.example.com/?hello=1&bye=2").equals(""));
 
-        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("http://1.2.3.4/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("1.2.3.4/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("https://api.example.com/one/two/").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two?hello=1").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com/hello/").equals("/hello"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two/").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com:8080/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("http://api.example.com/one/two#random2").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("api.example.com/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("api.example.com/one/two/#random").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError(".example.com/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("api.example.com/one/two?hello=1&bye=2").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("http://1.2.3.4/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("1.2.3.4/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("https://api.example.com/one/two/").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/one/two?hello=1").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/hello/").equals("/hello"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/one/two/").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com:8080/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("http://api.example.com/one/two#random2").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("api.example.com/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("api.example.com/one/two/#random").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError(".example.com/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("api.example.com/one/two?hello=1&bye=2").equals("/one/two"));
 
-        assert(normaliseURLPathOrThrowError("/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("one/two/").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("/one").equals("/one"));
-        assert(normaliseURLPathOrThrowError("one").equals("/one"));
-        assert(normaliseURLPathOrThrowError("one/").equals("/one"));
-        assert(normaliseURLPathOrThrowError("/one/two/").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("/one/two?hello=1").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("one/two?hello=1").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("/one/two/#random").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("one/two#random").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("one/two/").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("/one").equals("/one"));
+        assert (normaliseURLPathOrThrowError("one").equals("/one"));
+        assert (normaliseURLPathOrThrowError("one/").equals("/one"));
+        assert (normaliseURLPathOrThrowError("/one/two/").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("/one/two?hello=1").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("one/two?hello=1").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("/one/two/#random").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("one/two#random").equals("/one/two"));
 
-        assert(normaliseURLPathOrThrowError("localhost:4000/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("127.0.0.1:4000/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("127.0.0.1/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("https://127.0.0.1:80/one/two").equals("/one/two"));
-        assert(normaliseURLPathOrThrowError("/").equals(""));
+        assert (normaliseURLPathOrThrowError("localhost:4000/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("127.0.0.1:4000/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("127.0.0.1/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("https://127.0.0.1:80/one/two").equals("/one/two"));
+        assert (normaliseURLPathOrThrowError("/").equals(""));
 
-        assert(normaliseURLPathOrThrowError("/.netlify/functions/api").equals("/.netlify/functions/api"));
-        assert(normaliseURLPathOrThrowError("/netlify/.functions/api").equals("/netlify/.functions/api"));
-        assert(
-                normaliseURLPathOrThrowError("app.example.com/.netlify/functions/api").equals("/.netlify/functions/api")
-        );
-        assert(
-                normaliseURLPathOrThrowError("app.example.com/netlify/.functions/api").equals("/netlify/.functions/api")
-        );
-        assert(normaliseURLPathOrThrowError("/app.example.com").equals("/app.example.com"));
+        assert (normaliseURLPathOrThrowError("/.netlify/functions/api").equals("/.netlify/functions/api"));
+        assert (normaliseURLPathOrThrowError("/netlify/.functions/api").equals("/netlify/.functions/api"));
+        assert (normaliseURLPathOrThrowError("app.example.com/.netlify/functions/api")
+                .equals("/.netlify/functions/api"));
+        assert (normaliseURLPathOrThrowError("app.example.com/netlify/.functions/api")
+                .equals("/netlify/.functions/api"));
+        assert (normaliseURLPathOrThrowError("/app.example.com").equals("/app.example.com"));
     }
 
     @Test
     public void testURLDomainNormalisation() throws Exception {
-        assert(normaliseURLDomainOrThrowError("http://api.example.com").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("https://api.example.com").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com?hello=1").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com/hello").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com/").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com:8080").equals("http://api.example.com:8080"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com#random2").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("api.example.com/").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("api.example.com").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("api.example.com#random").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError(".example.com").equals("https://example.com"));
-        assert(normaliseURLDomainOrThrowError("api.example.com/?hello=1&bye=2").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("localhost").equals("http://localhost"));
-        assert(normaliseURLDomainOrThrowError("https://localhost").equals("https://localhost"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com").equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("https://api.example.com").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com?hello=1").equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com/hello").equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com/").equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com:8080").equals("http://api.example.com:8080"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com#random2").equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("api.example.com/").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("api.example.com").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("api.example.com#random").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError(".example.com").equals("https://example.com"));
+        assert (normaliseURLDomainOrThrowError("api.example.com/?hello=1&bye=2").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("localhost").equals("http://localhost"));
+        assert (normaliseURLDomainOrThrowError("https://localhost").equals("https://localhost"));
 
-        assert(normaliseURLDomainOrThrowError("http://api.example.com/one/two").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://1.2.3.4/one/two").equals("http://1.2.3.4"));
-        assert(normaliseURLDomainOrThrowError("https://1.2.3.4/one/two").equals("https://1.2.3.4"));
-        assert(normaliseURLDomainOrThrowError("1.2.3.4/one/two").equals("http://1.2.3.4"));
-        assert(normaliseURLDomainOrThrowError("https://api.example.com/one/two/").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com/one/two?hello=1").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("http://api.example.com/one/two#random2").equals("http://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("api.example.com/one/two").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError("api.example.com/one/two/#random").equals("https://api.example.com"));
-        assert(normaliseURLDomainOrThrowError(".example.com/one/two").equals("https://example.com"));
-        assert(normaliseURLDomainOrThrowError("localhost:4000").equals("http://localhost:4000"));
-        assert(normaliseURLDomainOrThrowError("127.0.0.1:4000").equals("http://127.0.0.1:4000"));
-        assert(normaliseURLDomainOrThrowError("127.0.0.1").equals("http://127.0.0.1"));
-        assert(normaliseURLDomainOrThrowError("https://127.0.0.1:80/").equals("https://127.0.0.1:80"));
-        assert(normaliseURLDomainOrThrowError("http://localhost.org:8080").equals("http://localhost.org:8080"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com/one/two").equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://1.2.3.4/one/two").equals("http://1.2.3.4"));
+        assert (normaliseURLDomainOrThrowError("https://1.2.3.4/one/two").equals("https://1.2.3.4"));
+        assert (normaliseURLDomainOrThrowError("1.2.3.4/one/two").equals("http://1.2.3.4"));
+        assert (normaliseURLDomainOrThrowError("https://api.example.com/one/two/").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com/one/two?hello=1")
+                .equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("http://api.example.com/one/two#random2")
+                .equals("http://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("api.example.com/one/two").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError("api.example.com/one/two/#random").equals("https://api.example.com"));
+        assert (normaliseURLDomainOrThrowError(".example.com/one/two").equals("https://example.com"));
+        assert (normaliseURLDomainOrThrowError("localhost:4000").equals("http://localhost:4000"));
+        assert (normaliseURLDomainOrThrowError("127.0.0.1:4000").equals("http://127.0.0.1:4000"));
+        assert (normaliseURLDomainOrThrowError("127.0.0.1").equals("http://127.0.0.1"));
+        assert (normaliseURLDomainOrThrowError("https://127.0.0.1:80/").equals("https://127.0.0.1:80"));
+        assert (normaliseURLDomainOrThrowError("http://localhost.org:8080").equals("http://localhost.org:8080"));
     }
 
     @Test
     public void testShouldDoInterceptionBasedOnUrl() throws Exception {
         // true cases without cookieDomain
-        assert(shouldDoInterceptionBasedOnUrl("api.example.com", "https://api.example.com", null));
-        assert(shouldDoInterceptionBasedOnUrl("http://api.example.com", "http://api.example.com", null));
-        assert(shouldDoInterceptionBasedOnUrl("api.example.com", "http://api.example.com", null));
-        assert(shouldDoInterceptionBasedOnUrl("https://api.example.com", "http://api.example.com", null));
-        assert(
-                shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "http://api.example.com:3000", null)
-        );
-        assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("https://localhost:3000", "https://localhost:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("http://localhost:3000", "http://localhost:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "https://localhost:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("localhost", "https://localhost", null));
-        assert(shouldDoInterceptionBasedOnUrl("http://localhost:3000", "https://localhost:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "127.0.0.1:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("https://127.0.0.1:3000", "https://127.0.0.1:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "http://127.0.0.1:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "https://127.0.0.1:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "https://127.0.0.1:3000", null));
-        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1", "https://127.0.0.1", null));
+        assert (shouldDoInterceptionBasedOnUrl("https://localhost:3000", "https://localhost:3001", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://localhost:3000", "http://localhost:3001", null));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:3001", null));
+        assert (shouldDoInterceptionBasedOnUrl("api.example.com", "https://api.example.com", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://api.example.com", "http://api.example.com", null));
+        assert (shouldDoInterceptionBasedOnUrl("api.example.com", "http://api.example.com", null));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com", "http://api.example.com", null));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "http://api.example.com:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("https://localhost:3000", "https://localhost:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://localhost:3000", "http://localhost:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3000", "https://localhost:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("localhost", "https://localhost", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://localhost:3000", "https://localhost:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "127.0.0.1:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("https://127.0.0.1:3000", "https://127.0.0.1:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "http://127.0.0.1:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "https://127.0.0.1:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "https://127.0.0.1:3000", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1", "https://127.0.0.1", null));
 
         // true cases with cookieDomain
-        assert(shouldDoInterceptionBasedOnUrl("api.example.com", "", "api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("http://api.example.com", "", "http://api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("api.example.com", "", ".example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://api.example.com", "", "http://api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://api.example.com", "", "https://api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "https://sub.api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", ".api.example.com"));
-        assert(shouldDoInterceptionBasedOnUrl("localhost:3000", "", "localhost:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("https://localhost:3000", "", ".localhost:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("localhost", "", "localhost"));
-        assert(shouldDoInterceptionBasedOnUrl("http://a.localhost:3000", "", ".localhost:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "", "127.0.0.1:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("https://127.0.0.1:3000", "", "https://127.0.0.1:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "http://127.0.0.1:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "", "https://127.0.0.1:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3000"));
-        assert(shouldDoInterceptionBasedOnUrl("http://127.0.0.1", "", "https://127.0.0.1"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".com"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk:3000", "", ".api.example.co.uk"));
-        assert(shouldDoInterceptionBasedOnUrl("https://sub1.api.example.co.uk:3000", "", ".api.example.co.uk"));
-        assert(shouldDoInterceptionBasedOnUrl("https://api.example.co.uk:3000", "", ".api.example.co.uk"));
-        assert(shouldDoInterceptionBasedOnUrl("https://api.example.co.uk:3000", "", "api.example.co.uk"));
+        assert (shouldDoInterceptionBasedOnUrl("api.example.com", "", "example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", "api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "example.com:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", "example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", "api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".sub.api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", "sub.api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("api.example.com", "", "api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("http://api.example.com", "", "http://api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("api.example.com", "", ".example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com", "", "http://api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com", "", "https://api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com", "", ".example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "https://sub.api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", ".api.example.com"));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3000", "", "localhost:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("https://localhost:3000", "", ".localhost:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("localhost", "", "localhost"));
+        assert (shouldDoInterceptionBasedOnUrl("http://a.localhost:3000", "", ".localhost:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "", "127.0.0.1:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("https://127.0.0.1:3000", "", "https://127.0.0.1:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "http://127.0.0.1:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("127.0.0.1:3000", "", "https://127.0.0.1:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3000"));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1", "", "https://127.0.0.1"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".com"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk:3000", "", ".api.example.co.uk"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub1.api.example.co.uk:3000", "", ".api.example.co.uk"));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.co.uk:3000", "", ".api.example.co.uk"));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.co.uk:3000", "", "api.example.co.uk"));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3000", "localhost:8080", null));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3001", "localhost", null));
+        assert (shouldDoInterceptionBasedOnUrl("https://api.example.com:3002", "https://api.example.com:3001",
+                null));
+        assert (shouldDoInterceptionBasedOnUrl("http://localhost.org", "localhost.org:2000", null));
+        assert (shouldDoInterceptionBasedOnUrl("http://localhost.org", "localhost", "localhost.org"));
+        assert (shouldDoInterceptionBasedOnUrl("localhost", "localhost", "localhost.org"));
+        assert (shouldDoInterceptionBasedOnUrl("localhost", "", "localhost:8080"));
+        assert (shouldDoInterceptionBasedOnUrl("http://localhost:80", "", "localhost:8080"));
+        assert (shouldDoInterceptionBasedOnUrl("localhost:3000", "", "localhost:8080"));
+        assert (shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3001"));
+        assert (shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3010"));
 
         // false cases with api
-        assert(!shouldDoInterceptionBasedOnUrl("localhost:3001", "localhost:3000", null));
-        assert(!shouldDoInterceptionBasedOnUrl("localhost:3001", "example.com", null));
-        assert(!shouldDoInterceptionBasedOnUrl("localhost:3001", "localhost", null));
-        assert(!shouldDoInterceptionBasedOnUrl("https://example.com", "https://api.example.com", null));
-        assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://a.api.example.com", null));
-        assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://example.com", null));
-        assert(!shouldDoInterceptionBasedOnUrl("https://example.com:3001", "https://api.example.com:3001", null));
-        assert(
-                !shouldDoInterceptionBasedOnUrl("https://api.example.com:3002", "https://api.example.com:3001", null)
-        );
+        assert (!shouldDoInterceptionBasedOnUrl("localhost", "localhost.org", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://a.api.example.com:3000",
+                null));
+        assert (!shouldDoInterceptionBasedOnUrl("google.com", "localhost.org", null));
+        assert (!shouldDoInterceptionBasedOnUrl("http://google.com", "localhost.org", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://google.com", "localhost.org", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://google.com:8080", "localhost.org", null));
+        assert (!shouldDoInterceptionBasedOnUrl("localhost:3001", "example.com", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://example.com", "https://api.example.com", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://a.api.example.com", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://api.example.com", "https://example.com", null));
+        assert (!shouldDoInterceptionBasedOnUrl("https://example.com:3001", "https://api.example.com:3001", null));
 
         // false cases with cookieDomain
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", ".example.com:3001"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "example.com"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", ".a.api.example.com"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "localhost"));
-        assert(!shouldDoInterceptionBasedOnUrl("http://127.0.0.1:3000", "", "https://127.0.0.1:3010"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk:3000", "", "api.example.co.uk"));
-        assert(!shouldDoInterceptionBasedOnUrl("https://sub.api.example.co.uk", "", "api.example.co.uk"));
+        assert (!shouldDoInterceptionBasedOnUrl("localhost", "", "localhost.org"));
+        assert (!shouldDoInterceptionBasedOnUrl("google.com", "", "localhost.org"));
+        assert (!shouldDoInterceptionBasedOnUrl("http://google.com", "", "localhost.org"));
+        assert (!shouldDoInterceptionBasedOnUrl("https://google.com", "", "localhost.org"));
+        assert (!shouldDoInterceptionBasedOnUrl("https://google.com:8080", "", "localhost.org"));
+        assert (!shouldDoInterceptionBasedOnUrl("https://api.example.com:3000", "", ".a.api.example.com"));
+        assert (!shouldDoInterceptionBasedOnUrl("https://sub.api.example.com:3000", "", "localhost"));
 
         // errors in input
         try {
-            assert(shouldDoInterceptionBasedOnUrl("/some/path", "", "api.example.co.uk"));
-            assert(false);
+            assert (shouldDoInterceptionBasedOnUrl("/some/path", "", "api.example.co.uk"));
+            assert (false);
         } catch (Exception e) {
             if (!e.getMessage().equals("Please provide a valid domain name")) {
                 throw e;
             }
         }
         try {
-            assert(shouldDoInterceptionBasedOnUrl("/some/path", "api.example.co.uk", null));
-            assert(false);
+            assert (shouldDoInterceptionBasedOnUrl("/some/path", "api.example.co.uk", null));
+            assert (false);
         } catch (Exception e) {
             if (!e.getMessage().equals("Please provide a valid domain name")) {
                 throw e;


### PR DESCRIPTION
## Summary of change

The `shouldDoInterceptionBasedOnUrl` function now returns true if `sessionTokenBackendDomain` is a valid subdomain of the URL's domain. This aligns with the behavior of browsers when sending cookies to subdomains.

## Related issues
- https://github.com/supertokens/supertokens-node/issues/826
- https://github.com/supertokens/supertokens-website/issues/217

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `app/src/main/java/com/supertokens/session/Version.java`
- [ ] Changes to the version if needed
   - In `app/build.gradle`
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2