### PR TITLE
fix: session refresh loop in all request interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-06-06
+
+### Changes
+
+- Fixed the session refresh loop in all the request interceptors that occurred when an API returned a 401 response despite a valid session. Interceptors now attempt to refresh the session a maximum of ten times before throwing an error. The retry limit is configurable via the `maxRetryAttemptsForSessionRefresh` option.
+
+
 ## [0.4.2] - 2024-05-28
 
 - re-Adds FDI 2.0 and 3.0 support

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-def publishVersionID = "0.4.2"
+def publishVersionID = "0.5.0"
 
 android {
     compileSdkVersion 32

--- a/app/src/main/java/com/supertokens/session/SuperTokens.java
+++ b/app/src/main/java/com/supertokens/session/SuperTokens.java
@@ -50,6 +50,7 @@ public class SuperTokens {
             @NonNull String apiDomain,
             @Nullable String apiBasePath,
             @Nullable Integer sessionExpiredStatusCode,
+            @Nullable Integer maxRetryAttemptsForSessionRefresh,
             @Nullable String sessionTokenBackendDomain,
             @Nullable String tokenTransferMethod,
             @Nullable CustomHeaderProvider customHeaderProvider,
@@ -63,6 +64,7 @@ public class SuperTokens {
                 apiDomain,
                 apiBasePath,
                 sessionExpiredStatusCode,
+                maxRetryAttemptsForSessionRefresh,
                 sessionTokenBackendDomain,
                 tokenTransferMethod,
                 customHeaderProvider,
@@ -260,6 +262,7 @@ public class SuperTokens {
         Context applicationContext;
         String apiBasePath;
         Integer sessionExpiredStatusCode;
+        Integer maxRetryAttemptsForSessionRefresh;
         String sessionTokenBackendDomain;
         CustomHeaderProvider customHeaderProvider;
         EventHandler eventHandler;
@@ -277,6 +280,11 @@ public class SuperTokens {
 
         public Builder sessionExpiredStatusCode(Integer sessionExpiredStatusCode) {
             this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+            return this;
+        }
+
+        public Builder maxRetryAttemptsForSessionRefresh(Integer maxRetryAttemptsForSessionRefresh) {
+            this.maxRetryAttemptsForSessionRefresh = maxRetryAttemptsForSessionRefresh;
             return this;
         }
 
@@ -301,7 +309,7 @@ public class SuperTokens {
         }
 
         public void build() throws MalformedURLException {
-            SuperTokens.init(applicationContext, apiDomain, apiBasePath, sessionExpiredStatusCode, sessionTokenBackendDomain, tokenTransferMethod, customHeaderProvider, eventHandler);
+            SuperTokens.init(applicationContext, apiDomain, apiBasePath, sessionExpiredStatusCode, maxRetryAttemptsForSessionRefresh, sessionTokenBackendDomain, tokenTransferMethod, customHeaderProvider, eventHandler);
         }
     }
 }

--- a/app/src/main/java/com/supertokens/session/Utils.java
+++ b/app/src/main/java/com/supertokens/session/Utils.java
@@ -83,6 +83,14 @@ public class Utils {
         String apiDomain;
         String apiBasePath;
         int sessionExpiredStatusCode;
+
+        /**
+         * This specifies the maximum number of times the interceptor will attempt to refresh
+         * the session  when a 401 Unauthorized response is received. If the number of retries
+         * exceeds this limit, no further attempts will be made to refresh the session, and
+         * and an error will be thrown.
+         */
+        int maxRetryAttemptsForSessionRefresh;
         String sessionTokenBackendDomain;
         CustomHeaderProvider customHeaderMapper;
         EventHandler eventHandler;
@@ -93,6 +101,7 @@ public class Utils {
                 String apiDomain,
                 String apiBasePath,
                 int sessionExpiredStatusCode,
+                int maxRetryAttemptsForSessionRefresh,
                 String sessionTokenBackendDomain,
                 String tokenTransferMethod,
                 CustomHeaderProvider customHeaderMapper,
@@ -100,6 +109,7 @@ public class Utils {
             this.apiDomain = apiDomain;
             this.apiBasePath = apiBasePath;
             this.sessionExpiredStatusCode = sessionExpiredStatusCode;
+            this.maxRetryAttemptsForSessionRefresh = maxRetryAttemptsForSessionRefresh;
             this.sessionTokenBackendDomain = sessionTokenBackendDomain;
             this.customHeaderMapper = customHeaderMapper;
             this.eventHandler = eventHandler;
@@ -153,6 +163,7 @@ public class Utils {
                 String apiDomain,
                 @Nullable String apiBasePath,
                 @Nullable Integer sessionExpiredStatusCode,
+                @Nullable Integer maxRetryAttemptsForSessionRefresh,
                 @Nullable String sessionTokenBackendDomain,
                 @Nullable String tokenTransferMethod,
                 @Nullable CustomHeaderProvider customHeaderProvider,
@@ -167,6 +178,11 @@ public class Utils {
             int _sessionExpiredStatusCode = 401;
             if (sessionExpiredStatusCode != null) {
                 _sessionExpiredStatusCode = sessionExpiredStatusCode;
+            }
+
+            int _maxRetryAttemptsForSessionRefresh = 10;
+            if (maxRetryAttemptsForSessionRefresh != null) {
+                _maxRetryAttemptsForSessionRefresh = maxRetryAttemptsForSessionRefresh;
             }
 
             String _sessionTokenBackendDomain = null;
@@ -190,7 +206,7 @@ public class Utils {
                 _tokenTransferMethod = tokenTransferMethod;
             }
 
-            return new NormalisedInputType(_apiDomain, _apiBasePath, _sessionExpiredStatusCode,
+            return new NormalisedInputType(_apiDomain, _apiBasePath, _sessionExpiredStatusCode, _maxRetryAttemptsForSessionRefresh,
                     _sessionTokenBackendDomain, _tokenTransferMethod, _customHeaderProvider, _eventHandler);
         }
     }

--- a/examples/with-thirdparty/README.md
+++ b/examples/with-thirdparty/README.md
@@ -20,10 +20,10 @@ dependencyResolutionManagement {
 }
 ```
 
-Add the folliwing to your app level `build.gradle`
+Add the following to your app level `build.gradle`
 
 ```gradle
-implementation("com.github.supertokens:supertokens-android:0.4.2")
+implementation("com.github.supertokens:supertokens-android:0.5.0")
 implementation ("com.google.android.gms:play-services-auth:20.7.0")
 implementation("com.squareup.retrofit2:retrofit:2.9.0")
 implementation("net.openid:appauth:0.11.1")

--- a/examples/with-thirdparty/app/build.gradle.kts
+++ b/examples/with-thirdparty/app/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.github.supertokens:supertokens-android:0.4.0")
+    implementation("com.github.supertokens:supertokens-android:0.5.0")
     implementation ("com.google.android.gms:play-services-auth:20.7.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("net.openid:appauth:0.11.1")

--- a/testHelpers/server/index.js
+++ b/testHelpers/server/index.js
@@ -507,6 +507,10 @@ app.get("/testError", (req, res) => {
     res.status(500).send("test error message");
 });
 
+app.get("/throw-401", (req, res) => {
+    res.status(401).send("Unauthorised");
+})
+
 app.get("/stop", async (req, res) => {
     process.exit();
 });

--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensOkHttpTest.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensOkHttpTest.java
@@ -82,6 +82,7 @@ public class SuperTokensOkHttpTest {
     private final String testCheckDeviceInfoAPIURL = testBaseURL + "/checkDeviceInfo";
     private final String testErrorAPIURL = testBaseURL + "/testError";
     private final String testPingAPIURL = testBaseURL + "/ping";
+    private final String throw401APIURL = testBaseURL + "/throw-401";
 
     private final int sessionExpiryCode = 401;
     private static OkHttpClient okHttpClient;
@@ -1051,6 +1052,122 @@ public class SuperTokensOkHttpTest {
         accessToken = SuperTokens.getAccessToken(context);
 
         assert accessToken != null;
+    }
+
+    @Test
+    public void okHttp_testBreakOutOfSessionRefreshLoopAfterDefaultMaxRetryAttempts() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .tokenTransferMethod("cookie")
+                .build();
+
+        JsonObject bodyJson = new JsonObject();
+        bodyJson.addProperty("userId", Constants.userId);
+        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), bodyJson.toString());
+        Request request = new Request.Builder()
+                .url(loginAPIURL)
+                .method("POST", body)
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .build();
+        Response loginResponse = okHttpClient.newCall(request).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+        loginResponse.close();
+
+        try {
+            Request throw401Request = new Request.Builder()
+                    .url(throw401APIURL)
+                    .build();
+            okHttpClient.newCall(throw401Request).execute();
+            throw new Exception("Expected the request to throw an error");
+        } catch (IOException e) {
+            assert e.getMessage().equals("Received a 401 response from http://127.0.0.1:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 10 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+        }
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 10) {
+            throw new Exception("Expected session refresh endpoint to be called 10 times but it was called " + sessionRefreshCalledCount + " times");
+        }
+    }
+
+    @Test
+    public void okHttp_testBreakOutOfSessionRefreshLoopAfterConfiguredMaxRetryAttempts() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .maxRetryAttemptsForSessionRefresh(5)
+                .tokenTransferMethod("cookie")
+                .build();
+
+        JsonObject bodyJson = new JsonObject();
+        bodyJson.addProperty("userId", Constants.userId);
+        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), bodyJson.toString());
+        Request request = new Request.Builder()
+                .url(loginAPIURL)
+                .method("POST", body)
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .build();
+        Response loginResponse = okHttpClient.newCall(request).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+        loginResponse.close();
+
+        try {
+            Request throw401Request = new Request.Builder()
+                    .url(throw401APIURL)
+                    .build();
+            okHttpClient.newCall(throw401Request).execute();
+            throw new Exception("Expected the request to throw an error");
+        } catch (IOException e) {
+            assert e.getMessage().equals("Received a 401 response from http://127.0.0.1:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 5 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+        }
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 5) {
+            throw new Exception("Expected session refresh endpoint to be called 5 times but it was called " + sessionRefreshCalledCount + " times");
+        }
+    }
+
+    @Test
+    public void okHttp_testShouldNotDoSessionRefreshIfMaxRetryAttemptsForSessionRefreshIsZero() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .maxRetryAttemptsForSessionRefresh(0)
+                .tokenTransferMethod("cookie")
+                .build();
+
+        JsonObject bodyJson = new JsonObject();
+        bodyJson.addProperty("userId", Constants.userId);
+        RequestBody body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), bodyJson.toString());
+        Request request = new Request.Builder()
+                .url(loginAPIURL)
+                .method("POST", body)
+                .addHeader("Accept", "application/json")
+                .addHeader("Content-Type", "application/json")
+                .build();
+        Response loginResponse = okHttpClient.newCall(request).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+        loginResponse.close();
+
+        try {
+            Request throw401Request = new Request.Builder()
+                    .url(throw401APIURL)
+                    .build();
+            okHttpClient.newCall(throw401Request).execute();
+            throw new Exception("Expected the request to throw an error");
+        } catch (IOException e) {
+            assert e.getMessage().equals("Received a 401 response from http://127.0.0.1:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 0 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+        }
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 0) {
+            throw new Exception("Expected session refresh endpoint to be called 0 times but it was called " + sessionRefreshCalledCount + " times");
+        }
     }
 
     //custom interceptors

--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensRetrofitHeaderTests.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensRetrofitHeaderTests.java
@@ -745,6 +745,83 @@ public class SuperTokensRetrofitHeaderTests {
         }
     }
 
+    @Test
+    public void retrofitHeaders_testBreakOutOfSessionRefreshLoopAfterDefaultMaxRetryAttempts() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .build();
+
+        JsonObject body = new JsonObject();
+        body.addProperty("userId", Constants.userId);
+        Response <Void> loginResponse = retrofitTestAPIService.login(body).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+
+        try {
+            Response<ResponseBody> userInfoResponse = retrofitTestAPIService.throw401().execute();
+        } catch (IOException e) {
+            assert e.getMessage().equals("Received a 401 response from http://127.0.0.1:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 10 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+        }
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 10) {
+            throw new Exception("Expected session refresh endpoint to be called 10 times but it was called " + sessionRefreshCalledCount + " times");
+        }
+    }
+
+    @Test
+    public void retrofitHeaders_testBreakOutOfSessionRefreshLoopAfterConfiguredMaxRetryAttempts() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .maxRetryAttemptsForSessionRefresh(5)
+                .build();
+
+        JsonObject body = new JsonObject();
+        body.addProperty("userId", Constants.userId);
+        Response <Void> loginResponse = retrofitTestAPIService.login(body).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+
+        try {
+            Response<ResponseBody> userInfoResponse = retrofitTestAPIService.throw401().execute();
+        } catch (IOException e) {
+            assert e.getMessage().equals("Received a 401 response from http://127.0.0.1:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 5 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+        }
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 5) {
+            throw new Exception("Expected session refresh endpoint to be called 5 times but it was called " + sessionRefreshCalledCount + " times");
+        }
+    }
+
+    @Test
+    public void retrofitHeaders_testShouldNotDoSessionRefreshIfMaxRetryAttemptsForSessionRefreshIsZero() throws Exception {
+        com.example.TestUtils.startST();
+        new SuperTokens.Builder(context, Constants.apiDomain)
+                .maxRetryAttemptsForSessionRefresh(0)
+                .build();
+
+        JsonObject body = new JsonObject();
+        body.addProperty("userId", Constants.userId);
+        Response <Void> loginResponse = retrofitTestAPIService.login(body).execute();
+        if (loginResponse.code() != 200) {
+            throw new Exception("Error making login request");
+        }
+
+        try {
+            Response<ResponseBody> userInfoResponse = retrofitTestAPIService.throw401().execute();
+        } catch (IOException e) {
+            assert e.getMessage().equals("Received a 401 response from http://127.0.0.1:8080/throw-401. Attempted to refresh the session and retry the request with the updated session tokens 0 times, but each attempt resulted in a 401 error. The maximum session refresh limit has been reached. Please investigate your API. To increase the session refresh attempts, update maxRetryAttemptsForSessionRefresh in the config.");
+        }
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 0) {
+            throw new Exception("Expected session refresh endpoint to be called 0 times but it was called " + sessionRefreshCalledCount + " times");
+        }
+    }
+
     class customInterceptors implements Interceptor {
         @NotNull
         @Override

--- a/testHelpers/testapp/app/src/test/java/com/example/example/android/RetrofitTestAPIService.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/android/RetrofitTestAPIService.java
@@ -88,4 +88,6 @@ public interface RetrofitTestAPIService {
     @POST("/multipleInterceptors")
     Call<ResponseBody> multipleInterceptors();
 
+    @GET("/throw-401")
+    Call<ResponseBody> throw401();
 }


### PR DESCRIPTION
## Summary of change

This PR fixes the session refresh loop in all the request interceptors that occurred when an API returned a 401 response despite a valid session. Interceptors now attempt to refresh the session a maximum of ten times before throwing an error. The retry limit is configurable via the `maxRetryAttemptsForSessionRefresh` option.

## Related issues
- Link to issue1 here
- Link to issue1 here

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `app/src/main/java/com/supertokens/session/Version.java`
- [x] Changes to the version if needed
   - In `app/build.gradle`
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.