### PR TITLE
fix: session refresh loop if expired token is passed in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-06-13
+
+### Changes
+
+- Fixed session refresh loop caused by passing an expired access token in the Authorization header.
+
 ## [0.5.0] - 2024-06-06
 
 ### Changes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-def publishVersionID = "0.5.0"
+def publishVersionID = "0.5.1"
 
 android {
     compileSdkVersion 32

--- a/app/src/main/java/com/supertokens/session/SuperTokensCustomHttpURLConnection.java
+++ b/app/src/main/java/com/supertokens/session/SuperTokensCustomHttpURLConnection.java
@@ -34,11 +34,23 @@ import java.util.Map;
 public class SuperTokensCustomHttpURLConnection extends HttpURLConnection {
     HttpURLConnection original;
     Context applicationContext;
+    private boolean wasAuthHeaderRemovedInitially = false;
 
     public SuperTokensCustomHttpURLConnection(HttpURLConnection original, Context applicationContext) {
         super(original.getURL());
         this.original = original;
         this.applicationContext = applicationContext;
+    }
+
+    public SuperTokensCustomHttpURLConnection(HttpURLConnection original, Context applicationContext, boolean wasAuthHeaderRemovedInitially) {
+        super(original.getURL());
+        this.original = original;
+        this.applicationContext = applicationContext;
+        this.wasAuthHeaderRemovedInitially = wasAuthHeaderRemovedInitially;
+    }
+
+    public boolean getWasAuthHeaderRemovedInitially() {
+        return wasAuthHeaderRemovedInitially;
     }
 
     @Override
@@ -249,9 +261,18 @@ public class SuperTokensCustomHttpURLConnection extends HttpURLConnection {
     }
 
     private boolean shouldAllowSettingAuthHeader(String value) {
+        // This check ensures that if the authorization header was removed initially (because it matched the local access token),
+        // it remains removed in subsequent retries even after the session is refreshed.
+        // This prevents the use of an expired access token which would no longer match the updated local access token.
+        if (wasAuthHeaderRemovedInitially) {
+            return false;
+        }
+
+
         String accessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, applicationContext);
         String refreshToken = Utils.getTokenForHeaderAuth(Utils.TokenType.REFRESH, applicationContext);
         if (accessToken != null && refreshToken != null && value.equals("Bearer " + accessToken)) {
+            wasAuthHeaderRemovedInitially = true;
             // We ignore the attempt to set the header because it matches the existing access token
             // which will get added by the SDK
             return false;
@@ -272,6 +293,14 @@ public class SuperTokensCustomHttpURLConnection extends HttpURLConnection {
                 return;
             }
         }
+        original.setRequestProperty(key, value);
+    }
+
+    // Sets the authorization header without performing the "shouldAllowSettingAuthHeader" check.
+    // This bypass is necessary because the "shouldAllowSettingAuthHeader" function tracks whether
+    // setting the auth header was disallowed, which is only intended for custom headers set by the user,
+    // not for headers set by our library code.
+    public void setRequestPropertyIgnoringOverride(String key, String value) {
         original.setRequestProperty(key, value);
     }
 

--- a/app/src/main/java/com/supertokens/session/SuperTokensCustomHttpURLConnection.java
+++ b/app/src/main/java/com/supertokens/session/SuperTokensCustomHttpURLConnection.java
@@ -271,7 +271,7 @@ public class SuperTokensCustomHttpURLConnection extends HttpURLConnection {
 
         String accessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, applicationContext);
         String refreshToken = Utils.getTokenForHeaderAuth(Utils.TokenType.REFRESH, applicationContext);
-        if (accessToken != null && refreshToken != null && value.equals("Bearer " + accessToken)) {
+        if (accessToken != null && refreshToken != null && (value.equals("Bearer " + accessToken) || value.equals("bearer " + accessToken))) {
             wasAuthHeaderRemovedInitially = true;
             // We ignore the attempt to set the header because it matches the existing access token
             // which will get added by the SDK

--- a/app/src/main/java/com/supertokens/session/SuperTokensInterceptor.java
+++ b/app/src/main/java/com/supertokens/session/SuperTokensInterceptor.java
@@ -48,7 +48,7 @@ public class SuperTokensInterceptor implements Interceptor {
             String accessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, context);
             String refreshToken = Utils.getTokenForHeaderAuth(Utils.TokenType.REFRESH, context);
 
-            if (accessToken != null && refreshToken != null && originalHeader.equals("Bearer " + accessToken)) {
+            if (accessToken != null && refreshToken != null && (originalHeader.equals("Bearer " + accessToken) || originalHeader.equals("bearer " + accessToken))) {
                 return true;
             }
         }

--- a/app/src/main/java/com/supertokens/session/Utils.java
+++ b/app/src/main/java/com/supertokens/session/Utils.java
@@ -319,10 +319,6 @@ public class Utils {
         return getFromStorage(name, context);
     }
 
-    public static Map<String, String> getAuthorizationHeaderIfRequired(Context context) {
-        return getAuthorizationHeaderIfRequired(false, context);
-    }
-
     // Checks if a key exists in a map regardless of case
     public static <T> T getIgnoreCase(Map<String, T> map, String key) {
         for (Map.Entry<String, T> entry : map.entrySet()) {
@@ -332,33 +328,28 @@ public class Utils {
         return null;
     }
 
-    public static Map<String, String> getAuthorizationHeaderIfRequired(boolean addRefreshToken, Context context) {
-        // We set the Authorization header even if the tokenTransferMethod preference
+    public static String getAuthorizationHeaderIfExists(boolean addRefreshToken, Context context) {
+        // We return the Authorization header even if the tokenTransferMethod preference
         // set in the config is cookies
         // since the active session may be using cookies. By default, we want to allow
         // users to continue these sessions.
         // The new session preference should be applied at the start of the next
         // session, if the backend allows it.
-        Map<String, String> headers = new HashMap<>();
         String accessToken = getTokenForHeaderAuth(TokenType.ACCESS, context);
         String refreshToken = getTokenForHeaderAuth(TokenType.REFRESH, context);
 
         // We don't always need the refresh token because that's only required by the
         // refresh call
-        // Still, we only add the Authorization header if both are present, because we
+        // Still, we only return the Authorization header if both are present, because we
         // are planning to add an option to expose the
         // access token to the frontend while using cookie based auth - so that users
         // can get the access token to use
         if (accessToken != null && refreshToken != null) {
-            if (getIgnoreCase(headers, "Authorization") != null) {
-                // no-op
-            } else {
-                String tokenToAdd = addRefreshToken ? refreshToken : accessToken;
-                headers.put("Authorization", "Bearer " + tokenToAdd);
-            }
+            String tokenToAdd = addRefreshToken ? refreshToken : accessToken;
+            return "Bearer " + tokenToAdd;
         }
 
-        return headers;
+        return null;
     }
 
     public static void fireSessionUpdateEventsIfNecessary(

--- a/examples/with-thirdparty/README.md
+++ b/examples/with-thirdparty/README.md
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
 Add the following to your app level `build.gradle`
 
 ```gradle
-implementation("com.github.supertokens:supertokens-android:0.5.0")
+implementation("com.github.supertokens:supertokens-android:0.5.1")
 implementation ("com.google.android.gms:play-services-auth:20.7.0")
 implementation("com.squareup.retrofit2:retrofit:2.9.0")
 implementation("net.openid:appauth:0.11.1")

--- a/examples/with-thirdparty/app/build.gradle.kts
+++ b/examples/with-thirdparty/app/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.github.supertokens:supertokens-android:0.5.0")
+    implementation("com.github.supertokens:supertokens-android:0.5.1")
     implementation ("com.google.android.gms:play-services-auth:20.7.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("net.openid:appauth:0.11.1")

--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensHttpURLConnectionTest.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensHttpURLConnectionTest.java
@@ -904,7 +904,7 @@ public class SuperTokensHttpURLConnectionTest {
     }
 
     @Test
-    public void httpUrlConnection_testThatAuthHeaderIsNotIgnoredEvenIfItMatchesTheStoredAccessToken() throws Exception {
+    public void httpUrlConnection_testThatAuthHeaderIsNotIgnoredIfItDoesntMatchTheStoredAccessToken() throws Exception {
         com.example.TestUtils.startST();
         new SuperTokens.Builder(context, Constants.apiDomain).build();
 
@@ -930,9 +930,6 @@ public class SuperTokensHttpURLConnectionTest {
         }
 
         loginRequestConnection.disconnect();
-
-        Thread.sleep(5000);
-        Utils.setToken(Utils.TokenType.ACCESS, "myOwnHeHe", context);
 
         HttpURLConnection connection = SuperTokensHttpURLConnection.newRequest(new URL(baseCustomAuthUrl), new SuperTokensHttpURLConnection.PreConnectCallback() {
             @Override
@@ -1103,5 +1100,64 @@ public class SuperTokensHttpURLConnectionTest {
         if (sessionRefreshCalledCount != 0) {
             throw new Exception("Expected session refresh endpoint to be called 0 times but it was called " + sessionRefreshCalledCount + " times");
         }
+    }
+    
+    @Test
+    public void  httpUrlConnection_shouldNotEndUpInRefreshLoopIfExpiredAccessTokenWasPassedInHeaders() throws Exception{
+        com.example.TestUtils.startST(1, true, 144000);
+        new SuperTokens.Builder(context, Constants.apiDomain).build();
+
+        //login request
+        HttpURLConnection loginRequestConnection = SuperTokensHttpURLConnection.newRequest(new URL(loginAPIURL), new SuperTokensHttpURLConnection.PreConnectCallback() {
+            @Override
+            public void doAction(HttpURLConnection con) throws IOException {
+                con.setDoOutput(true);
+                con.setRequestMethod("POST");
+                con.setRequestProperty("Accept", "application/json");
+                con.setRequestProperty("Content-Type", "application/json");
+
+                JsonObject bodyJson = new JsonObject();
+                bodyJson.addProperty("userId", Constants.userId);
+
+                OutputStream outputStream = con.getOutputStream();
+                outputStream.write(bodyJson.toString().getBytes(StandardCharsets.UTF_8));
+                outputStream.close();
+            }
+        });
+
+        if (loginRequestConnection.getResponseCode() != 200) {
+            throw new Exception("Login request failed");
+        }
+
+        loginRequestConnection.disconnect();
+
+        String expiredAccessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, context);
+
+        // wait for access token expiry
+        Thread.sleep(2000);
+
+        int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 0) {
+            throw new Exception("Expected session refresh endpoint to be called 0 times but it was called " + sessionRefreshCalledCount + " times");
+        }
+
+        HttpURLConnection userInfoRequestConnection = SuperTokensHttpURLConnection.newRequest(new URL(userInfoAPIURL), new SuperTokensHttpURLConnection.PreConnectCallback() {
+            @Override
+            public void doAction(HttpURLConnection con) throws IOException {
+                con.setRequestMethod("GET");
+                con.setRequestProperty("Authorization", "Bearer " +  expiredAccessToken);
+            }
+        });
+
+        if (userInfoRequestConnection.getResponseCode() != 200) {
+            throw new Exception("userInfo api failed");
+        }
+
+        sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
+        if (sessionRefreshCalledCount != 1) {
+            throw new Exception("Expected session refresh endpoint to be called 1 time but it was called " + sessionRefreshCalledCount + " times");
+        }
+
+        userInfoRequestConnection.disconnect();
     }
 }


### PR DESCRIPTION
## Summary of change
Fixes #72 

## Related issues
- https://github.com/supertokens/supertokens-android/issues/72

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `app/src/main/java/com/supertokens/session/Version.java`
- [ ] Changes to the version if needed
   - In `app/build.gradle`
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.