### PR TITLE
fix: increase token expiry time in tests

### DIFF
--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensHttpURLConnectionTest.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensHttpURLConnectionTest.java
@@ -1104,7 +1104,7 @@ public class SuperTokensHttpURLConnectionTest {
     
     @Test
     public void httpUrlConnection_shouldNotRefreshLoopWhenExpiredTokenPassedInHeadersBeforeDoAction() throws Exception{
-        com.example.TestUtils.startST(1, true, 144000);
+        com.example.TestUtils.startST(3, true, 144000);
         new SuperTokens.Builder(context, Constants.apiDomain).build();
 
         //login request
@@ -1132,7 +1132,7 @@ public class SuperTokensHttpURLConnectionTest {
         loginRequestConnection.disconnect();
 
         // wait for access token expiry
-        Thread.sleep(2000);
+        Thread.sleep(4000);
 
         String expiredAccessToken = Utils.getTokenForHeaderAuth(Utils.TokenType.ACCESS, context);
 
@@ -1163,7 +1163,7 @@ public class SuperTokensHttpURLConnectionTest {
 
     @Test
     public void httpUrlConnection_shouldNotRefreshLoopWhenExpiredTokenRetrievedInsideDoAction() throws Exception{
-        com.example.TestUtils.startST(1, true, 144000);
+        com.example.TestUtils.startST(3, true, 144000);
         new SuperTokens.Builder(context, Constants.apiDomain).build();
 
         //login request
@@ -1191,7 +1191,7 @@ public class SuperTokensHttpURLConnectionTest {
         loginRequestConnection.disconnect();
 
         // wait for access token expiry
-        Thread.sleep(2000);
+        Thread.sleep(4000);
 
         int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
         if (sessionRefreshCalledCount != 0) {

--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensOkHttpHeaderTests.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensOkHttpHeaderTests.java
@@ -1220,7 +1220,7 @@ public class SuperTokensOkHttpHeaderTests {
 
     @Test
     public void okHttpHeaders_shouldNotEndUpInRefreshLoopIfExpiredAccessTokenWasPassedInHeaders() throws Exception {
-        com.example.TestUtils.startST(1, true, 144000);
+        com.example.TestUtils.startST(3, true, 144000);
         new SuperTokens.Builder(context, Constants.apiDomain)
                 .build();
         JsonObject bodyJson = new JsonObject();
@@ -1239,7 +1239,7 @@ public class SuperTokensOkHttpHeaderTests {
         loginResponse.close();
 
         // wait for the token to expire
-        Thread.sleep(2000);
+        Thread.sleep(4000);
 
         int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
         if (sessionRefreshCalledCount != 0) {

--- a/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensRetrofitHeaderTests.java
+++ b/testHelpers/testapp/app/src/test/java/com/example/example/SuperTokensRetrofitHeaderTests.java
@@ -821,7 +821,7 @@ public class SuperTokensRetrofitHeaderTests {
 
     @Test
     public void retrofitHeaders_shouldNotEndUpInRefreshLoopIfExpiredAccessTokenWasPassedInHeaders() throws Exception {
-        com.example.TestUtils.startST(1, true, 144000);
+        com.example.TestUtils.startST(3, true, 144000);
         new SuperTokens.Builder(context, Constants.apiDomain)
                 .build();
 
@@ -833,7 +833,7 @@ public class SuperTokensRetrofitHeaderTests {
         }
 
         // wait for the token to expire
-        Thread.sleep(2000);
+        Thread.sleep(4000);
 
         int sessionRefreshCalledCount = com.example.TestUtils.getRefreshTokenCounter();
         if (sessionRefreshCalledCount != 0) {


### PR DESCRIPTION
## Summary of change

This PR increases token expiry time in tests from 1 second to 3 seconds. This could be the reason behind flaky tests.

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `app/src/main/java/com/supertokens/session/Version.java`
- [ ] Changes to the version if needed
   - In `app/build.gradle`
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
