### PR TITLE
fix: remove redundant remove tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2024-07-12
+
+### Changes
+
+- Removed redundant calls to `removeToken`
+
 ## [0.5.1] - 2024-06-13
 
 ### Changes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
-def publishVersionID = "0.5.1"
+def publishVersionID = "0.5.2"
 
 android {
     compileSdkVersion 32

--- a/app/src/main/java/com/supertokens/session/FrontToken.java
+++ b/app/src/main/java/com/supertokens/session/FrontToken.java
@@ -118,6 +118,7 @@ public class FrontToken {
     }
 
     public static void removeToken(Context context) {
+        AntiCSRF.removeToken(applicationContext);
         synchronized (tokenLock) {
             removeTokenFromStorage(context);
             // We are clearing all stored tokens here, because:


### PR DESCRIPTION
## Summary of change

fix: remove redundant removeToken calls

## Related issues
- https://github.com/supertokens/supertokens-website/pull/265
- https://github.com/supertokens/supertokens-react-native/pull/127
- https://github.com/supertokens/supertokens-android/pull/75
- https://github.com/supertokens/supertokens-flutter/pull/61
- https://github.com/supertokens/supertokens-ios/pull/67

## Test Plan
Existing tests should cover this and keep working

## Documentation changes
N/A


## Checklist for important updates
- [x] Changelog has been updated
- [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `app/src/main/java/com/supertokens/session/Version.java`
- [x] Changes to the version if needed
   - In `app/build.gradle`
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
